### PR TITLE
fix(stream): prevent CPU drift from abort listener leak

### DIFF
--- a/src/baichuan/stream/BaichuanRtspServer.ts
+++ b/src/baichuan/stream/BaichuanRtspServer.ts
@@ -420,6 +420,7 @@ export class BaichuanRtspServer extends EventEmitter<{
     sampleRate: number | null;
     microseconds: number | null;
     videoType?: "H264" | "H265";
+    isKeyframe?: boolean;
   }> | null = null;
   private noClientAutoStopTimer: NodeJS.Timeout | undefined;
   /** Fires if camera never sends frames after stream start (sleeping), even with clients connected. */
@@ -2671,15 +2672,22 @@ export class BaichuanRtspServer extends EventEmitter<{
           this.setFlowVideoType(frame.videoType, "native stream");
         }
 
-        // Extract parameter sets for SDP.
-        this.flow.extractParameterSets(frame.data);
-        const { hasParamSets } = this.flow.getFmtp();
-        if (hasParamSets) {
+        // Extract parameter sets for SDP — only until we have them.
+        // Calling extractParameterSets on every frame (after SPS/PPS are known) performs
+        // an O(frame_size) NAL scan for nothing; skip it once params are in hand.
+        if (!this.flow.getFmtp().hasParamSets) {
+          this.flow.extractParameterSets(frame.data);
+        }
+        if (this.flow.getFmtp().hasParamSets) {
           this.markFirstFrameReceived();
         }
 
         // Add to prebuffer ring for IDR-aligned fast startup on client connect.
-        const isKeyframe = this.isRawFrameKeyframe(frame);
+        // Prefer the isKeyframe flag already set by createNativeStream/videoAccessUnit;
+        // fall back to NAL inspection only when the field is absent.
+        const isKeyframe = typeof frame.isKeyframe === "boolean"
+          ? frame.isKeyframe
+          : this.isRawFrameKeyframe(frame);
         this.prebuffer.push({
           frame: { ...frame, data: Buffer.from(frame.data) },
           time: Date.now(),

--- a/src/rfc/helpers.ts
+++ b/src/rfc/helpers.ts
@@ -386,6 +386,16 @@ export async function* createNativeStream(
   let streamStarted = false;
   let closed = false;
 
+  // Hoisted so the finally block can detach the abort listener even when the
+  // try-body throws before the listener is wired up (or after, on any exit path).
+  const signal = options?.signal;
+  let sleepResolve: (() => void) | null = null;
+  const handleAbort = () => {
+    const r = sleepResolve;
+    sleepResolve = null;
+    r?.();
+  };
+
   const onError = (_error: Error) => {
     closed = true;
     // Do not throw from an event callback: it can crash the process asynchronously.
@@ -542,7 +552,18 @@ export async function* createNativeStream(
 
     streamStarted = true;
 
-    const signal = options?.signal;
+    // Single abort listener for the generator's entire lifetime.
+    // Per-sleep-cycle listeners would accumulate because each sleep adds one listener
+    // that is never removed until the signal is aborted (the Promise resolves but the
+    // listener stays). At 30 fps this grows to tens of thousands of closures in < 1 hour,
+    // causing progressive heap growth and increasing GC CPU.
+    if (signal) {
+      if (signal.aborted) {
+        closed = true;
+      } else {
+        signal.addEventListener("abort", handleAbort);
+      }
+    }
 
     // Yield frames as they arrive
     while (!closed && !(signal?.aborted)) {
@@ -551,37 +572,33 @@ export async function* createNativeStream(
         yield frame;
       } else {
         // Wait for next frame, waking immediately if the fanout signals cancellation.
-        // Without the abort listener the generator loops indefinitely with 1-second
-        // sleeps when no frames arrive (sleeping camera), making generator.return()
-        // unable to process because no yield ever occurs.
+        // The single handleAbort listener (registered above) wakes us here when aborted.
         await new Promise<void>((resolve) => {
           frameResolve = resolve;
+          sleepResolve = resolve;
           const timer = setTimeout(() => {
+            // Guard against a stale timer (from a previous sleep cycle) clearing the
+            // current iteration's sleepResolve / frameResolve.
+            if (sleepResolve === resolve) sleepResolve = null;
             if (frameResolve === resolve) {
               frameResolve = null;
               resolve();
             }
           }, 1000);
-          if (signal) {
-            const onAbort = () => {
-              clearTimeout(timer);
-              if (frameResolve === resolve) frameResolve = null;
-              resolve();
-            };
-            if (signal.aborted) {
-              clearTimeout(timer);
-              frameResolve = null;
-              resolve();
-            } else {
-              signal.addEventListener("abort", onAbort, { once: true });
-            }
+          if (signal?.aborted) {
+            clearTimeout(timer);
+            sleepResolve = null;
+            frameResolve = null;
+            resolve();
           }
         });
+        sleepResolve = null;
       }
     }
   } finally {
     // Cleanup
     closed = true;
+    if (signal) signal.removeEventListener("abort", handleAbort);
     try {
       await videoStream.stop();
     } catch {

--- a/test/lib/create-native-stream-abort.test.ts
+++ b/test/lib/create-native-stream-abort.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Regression test for the createNativeStream abort-listener leak.
+ *
+ * Pre-fix: every idle sleep cycle inside the generator registered a fresh
+ * `signal.addEventListener("abort", onAbort, { once: true })`. The `{ once }`
+ * flag only auto-detaches the listener once it fires. When the sleep ended
+ * via a frame arrival (the common case), the listener stayed attached and
+ * accumulated linearly. Under live streaming at 30 fps this produced tens
+ * of thousands of retained closures per hour, growing the heap and
+ * progressively slowing the EventTarget dispatch path (visible CPU drift).
+ *
+ * Post-fix: a single lifetime listener is attached once and removed in the
+ * `finally` block. This test asserts the listener count on the signal
+ * stays bounded regardless of how many sleep cycles the generator goes
+ * through.
+ */
+
+import { EventEmitter } from "node:events";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mocks: stub BaichuanVideoStream so no real socket / camera is required.
+// ---------------------------------------------------------------------------
+
+class FakeVideoStream extends EventEmitter {
+  async start(): Promise<void> {
+    // no-op; the generator only awaits this once.
+  }
+  async stop(): Promise<void> {
+    // no-op; cleanup path.
+  }
+}
+
+let lastFakeStream: FakeVideoStream | null = null;
+
+vi.mock("../../src/baichuan/stream/BaichuanVideoStream.js", () => ({
+  BaichuanVideoStream: vi.fn().mockImplementation(() => {
+    const s = new FakeVideoStream();
+    lastFakeStream = s;
+    return s;
+  }),
+}));
+
+// Import AFTER vi.mock so the mocked BaichuanVideoStream is used.
+import { createNativeStream } from "../../src/rfc/helpers.js";
+
+// ---------------------------------------------------------------------------
+// Helper: a minimal AbortSignal that exposes its current listener count.
+// We wrap a native AbortController and count add/remove calls — the WHATWG
+// AbortSignal API does not expose listener counts directly.
+// ---------------------------------------------------------------------------
+
+function makeCountedAbortController(): {
+  controller: AbortController;
+  signal: AbortSignal;
+  abortListenerCount: () => number;
+} {
+  const controller = new AbortController();
+  let count = 0;
+  const realAdd = controller.signal.addEventListener.bind(controller.signal);
+  const realRemove = controller.signal.removeEventListener.bind(controller.signal);
+  // Intercept add/remove for the "abort" event only.
+  controller.signal.addEventListener = ((
+    type: string,
+    listener: any,
+    options?: any,
+  ) => {
+    if (type === "abort") count++;
+    realAdd(type, listener, options);
+  }) as typeof controller.signal.addEventListener;
+  controller.signal.removeEventListener = ((
+    type: string,
+    listener: any,
+    options?: any,
+  ) => {
+    if (type === "abort") count = Math.max(0, count - 1);
+    realRemove(type, listener, options);
+  }) as typeof controller.signal.removeEventListener;
+  return {
+    controller,
+    signal: controller.signal,
+    abortListenerCount: () => count,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Minimal ReolinkBaichuanApi stub. createNativeStream tries to acquire a
+// dedicated session; we return a dummy client so it does not fall back to
+// api.client (which we leave undefined to ensure the dedicated path is hit).
+// ---------------------------------------------------------------------------
+
+function buildMockApi() {
+  return {
+    client: {},
+    logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+    createDedicatedSession: vi.fn().mockResolvedValue({
+      client: {},
+      release: vi.fn().mockResolvedValue(undefined),
+    }),
+  } as any;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("createNativeStream — abort listener lifecycle", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    lastFakeStream = null;
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("attaches at most one abort listener regardless of sleep cycles", async () => {
+    const { controller, signal, abortListenerCount } = makeCountedAbortController();
+    const api = buildMockApi();
+
+    const gen = createNativeStream(api, 0, "main", { signal });
+
+    // Drive past the 5 s codec-info race. After this point the generator is
+    // sitting in its sleep/yield loop.
+    const firstFramePromise = gen.next();
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    // The generator is now alternating: short setTimeout(1000) sleeps
+    // interleaved with frame deliveries from the fake stream's
+    // videoAccessUnit emitter.
+    expect(lastFakeStream).not.toBeNull();
+    const fake = lastFakeStream!;
+
+    // Helper: emit one synthetic H.264 frame.
+    const emitFrame = () => {
+      fake.emit("videoAccessUnit", {
+        data: Buffer.from([0x00, 0x00, 0x00, 0x01, 0x65]),
+        isKeyframe: true,
+        videoType: "H264",
+        microseconds: 0,
+      });
+    };
+
+    // Resolve the first sleep with a frame so .next() returns.
+    emitFrame();
+    await firstFramePromise;
+
+    // Run 200 sleep→frame cycles. Pre-fix this would attach 200 listeners.
+    for (let i = 0; i < 200; i++) {
+      const p = gen.next();
+      // Let the generator enter the sleep promise.
+      await Promise.resolve();
+      // Advance a small slice so the setTimeout(1000) is set but not fired.
+      await vi.advanceTimersByTimeAsync(10);
+      emitFrame();
+      await p;
+    }
+
+    // Post-fix: a single lifetime listener (≤ 1).
+    expect(abortListenerCount()).toBeLessThanOrEqual(1);
+
+    // Cleanly tear down the generator so the finally block runs.
+    controller.abort();
+    await gen.return(undefined);
+
+    // After finally → listener removed.
+    expect(abortListenerCount()).toBe(0);
+  });
+
+  it("aborting the signal wakes the idle sleep promptly", async () => {
+    const { controller, signal, abortListenerCount } = makeCountedAbortController();
+    const api = buildMockApi();
+
+    const gen = createNativeStream(api, 0, "main", { signal });
+
+    // Drive past codec-info race and into the sleep loop with no frames.
+    const next = gen.next();
+    await vi.advanceTimersByTimeAsync(5_000);
+    // Let the empty queue path enter the sleep promise.
+    await Promise.resolve();
+
+    // Pre-fix: this would have N listeners by now (depending on cycles).
+    // Post-fix: exactly one listener.
+    expect(abortListenerCount()).toBe(1);
+
+    // Aborting wakes the sleep and ends the loop without waiting for the
+    // 1-second timeout.
+    controller.abort();
+    // The generator must complete; advance only a tiny slice — proves we
+    // did not wait for the 1 s fallback timer.
+    await vi.advanceTimersByTimeAsync(0);
+    const result = await next;
+    expect(result.done).toBe(true);
+
+    // Finally has run → listener detached.
+    expect(abortListenerCount()).toBe(0);
+  });
+});

--- a/test/lib/create-native-stream-abort.test.ts
+++ b/test/lib/create-native-stream-abort.test.ts
@@ -34,7 +34,7 @@ class FakeVideoStream extends EventEmitter {
 let lastFakeStream: FakeVideoStream | null = null;
 
 vi.mock("../../src/baichuan/stream/BaichuanVideoStream.js", () => ({
-  BaichuanVideoStream: vi.fn().mockImplementation(() => {
+  BaichuanVideoStream: vi.fn().mockImplementation(function () {
     const s = new FakeVideoStream();
     lastFakeStream = s;
     return s;


### PR DESCRIPTION
## Summary

This PR addresses a progressive CPU increase observed during long-running native stream rebroadcasting.

I was seeing CPU usage grow steadily during the first 45-60 minutes of streaming, then eventually stabilize at a higher level. After this fix, CPU usage has remained stable for several hours in the same scenario.

The likely root cause was an abort listener leak in `createNativeStream`. The generator was registering a new `abort` listener on every idle wait cycle, but those listeners were only removed when the signal was actually aborted. During normal streaming, idle waits are usually resolved by incoming frames, so the listeners stayed attached and accumulated over time.

This change replaces that per-cycle listener registration with a single listener for the lifetime of the generator, and guarantees that it is removed in the cleanup path.

 The implementation was supported by agent-assisted investigation and validated through code analysis and direct observations: after applying the fix, the previous CPU growth pattern no longer appears during multi-hour streaming.

## Details

Besides the listener lifecycle fix, the PR also includes two small stream-path optimizations:

- native stream frames now carry the existing `isKeyframe` information into the RTSP fan-out path, avoiding redundant keyframe detection when available;
- SDP parameter-set extraction is skipped once parameter sets are already known, avoiding repeated frame scans that no longer add useful information.

A regression test was added for the listener lifecycle. It verifies that repeated sleep/frame cycles keep the abort listener count bounded, that abort still wakes the generator promptly, and that the listener is removed when the generator exits.

## Tests

Added regression coverage:

```bash
npx vitest run test/lib/create-native-stream-abort.test.ts