### PR TITLE
fix(webrtc): accept Buffer/PCM on intercom DataChannel

### DIFF
--- a/src/baichuan/stream/BaichuanWebRTCServer.ts
+++ b/src/baichuan/stream/BaichuanWebRTCServer.ts
@@ -6,7 +6,8 @@
  *
  * Architecture:
  * - Camera → Baichuan native stream → H.264/H.265 frames → RTP → WebRTC
- * - Browser mic → WebRTC DataChannel → ADPCM encoding → Baichuan Talk → Camera speaker
+ * - Browser mic → WebRTC DataChannel (PCM or ADPCM) → encodeImaAdpcm as needed
+ *   → Baichuan Talk → Camera speaker
  *
  * Usage:
  * ```typescript
@@ -36,6 +37,7 @@ import type { StreamProfile } from "../../reolink/baichuan/types";
 import type { ReolinkBaichuanApi } from "../../reolink/baichuan/ReolinkBaichuanApi";
 import type { NativeVideoStreamVariant } from "../../reolink/baichuan/types";
 import { createNativeStream, Intercom } from "../../rfc/helpers";
+import { encodeImaAdpcm } from "../../reolink/baichuan/utils/imaAdpcm";
 import { detectVideoCodecFromNal } from "./BcMediaAnnexBDecoder";
 import { AacToOpusTranscoder } from "./AacToOpusTranscoder";
 import {
@@ -43,6 +45,67 @@ import {
   isH264KeyframeAnnexB,
   splitAnnexBToNalPayloads as splitH264AnnexBToNalPayloads,
 } from "./H264Converter";
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/**
+ * Normalize a WebRTC DataChannel binary payload to a Node Buffer.
+ *
+ * - Browser `RTCDataChannel` with `binaryType = "arraybuffer"` → ArrayBuffer
+ * - werift (Node) delivers binary messages as Buffer
+ * - TypedArray views (e.g. Int16Array PCM from the Manager UI)
+ *
+ * Returning null means the message is not binary audio and should be ignored.
+ */
+export function normalizeIntercomPayload(data: unknown): Buffer | null {
+  if (Buffer.isBuffer(data)) return data;
+  if (data instanceof ArrayBuffer) return Buffer.from(data);
+  if (ArrayBuffer.isView(data)) {
+    return Buffer.from(data.buffer, data.byteOffset, data.byteLength);
+  }
+  return null;
+}
+
+/**
+ * Reolink TalkAbility default: lengthPerEncoder=1024 → blockSize 512 ADPCM
+ * payload bytes + 4-byte IMA header = 516-byte full blocks.
+ */
+const REOLINK_TALK_ADPCM_BLOCK_SIZE = 512;
+const REOLINK_TALK_FULL_BLOCK_SIZE = REOLINK_TALK_ADPCM_BLOCK_SIZE + 4;
+
+/**
+ * Convert an intercom DataChannel payload into ADPCM full blocks for
+ * `Intercom.sendAudio()`.
+ *
+ * Preferred path (Manager UI): raw PCM Int16 LE, 1024 samples (2048 bytes) or
+ * 1025 samples (2050 bytes). Encoded with {@link encodeImaAdpcm} so framing
+ * matches Reolink (first sample as predictor, step index 0 per block).
+ *
+ * Legacy paths:
+ * - 512-byte nibble-only ADPCM → prepend zero header (best-effort)
+ * - 516-byte (or multiple) full blocks → pass through
+ */
+export function prepareIntercomAudioForTalk(audioData: Buffer): Buffer {
+  // PCM Int16 LE from the browser (TalkAbility lengthPerEncoder samples).
+  if (audioData.length === 2048 || audioData.length === 2050) {
+    const pcm = new Int16Array(
+      audioData.buffer,
+      audioData.byteOffset,
+      audioData.length / 2,
+    );
+    return encodeImaAdpcm(pcm, REOLINK_TALK_ADPCM_BLOCK_SIZE);
+  }
+  // Legacy: packed ADPCM nibbles without IMA header.
+  if (audioData.length === REOLINK_TALK_ADPCM_BLOCK_SIZE) {
+    const block = Buffer.alloc(REOLINK_TALK_FULL_BLOCK_SIZE);
+    audioData.copy(block, 4);
+    return block;
+  }
+  // Already full block(s).
+  return audioData;
+}
 
 // ============================================================================
 // Types
@@ -397,15 +460,26 @@ export class BaichuanWebRTCServer extends EventEmitter {
       };
 
       dataChannel.onmessage = async (event: any) => {
-        // Handle incoming audio from browser for intercom
-        if (session.intercom && event.data instanceof ArrayBuffer) {
-          try {
-            const audioData = Buffer.from(event.data);
-            await session.intercom.sendAudio(audioData);
-            session.stats.intercomBytesSent += audioData.length;
-          } catch (err) {
-            this.log("error", `Failed to send intercom audio: ${err}`);
+        // Handle incoming audio from browser for intercom.
+        // werift delivers binary DC messages as Node Buffers (not ArrayBuffer);
+        // browsers may send ArrayBuffer / TypedArray (PCM Int16 or ADPCM).
+        if (!session.intercom) return;
+        try {
+          const raw = normalizeIntercomPayload(event.data);
+          if (!raw) {
+            this.log(
+              "warn",
+              `Ignoring intercom DC message of unsupported type: ${
+                event.data == null ? "null" : typeof event.data
+              }`,
+            );
+            return;
           }
+          const audioData = prepareIntercomAudioForTalk(raw);
+          await session.intercom.sendAudio(audioData);
+          session.stats.intercomBytesSent += audioData.length;
+        } catch (err) {
+          this.log("error", `Failed to send intercom audio: ${err}`);
         }
       };
 

--- a/test/lib/webrtc-intercom-payload.test.ts
+++ b/test/lib/webrtc-intercom-payload.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import {
+  normalizeIntercomPayload,
+  prepareIntercomAudioForTalk,
+} from "../../src/baichuan/stream/BaichuanWebRTCServer";
+import { encodeImaAdpcm } from "../../src/reolink/baichuan/utils/imaAdpcm";
+
+describe("normalizeIntercomPayload", () => {
+  it("accepts Node Buffer (werift DC path)", () => {
+    const buf = Buffer.from([1, 2, 3]);
+    expect(normalizeIntercomPayload(buf)?.equals(buf)).toBe(true);
+  });
+
+  it("accepts ArrayBuffer", () => {
+    const ab = new Uint8Array([4, 5, 6]).buffer;
+    expect(normalizeIntercomPayload(ab)?.equals(Buffer.from([4, 5, 6]))).toBe(
+      true,
+    );
+  });
+
+  it("accepts TypedArray views with non-zero byteOffset", () => {
+    const backing = new ArrayBuffer(8);
+    const view = new Uint8Array(backing, 2, 3);
+    view.set([7, 8, 9]);
+    expect(normalizeIntercomPayload(view)?.equals(Buffer.from([7, 8, 9]))).toBe(
+      true,
+    );
+  });
+
+  it("returns null for non-binary payloads", () => {
+    expect(normalizeIntercomPayload("nope")).toBeNull();
+    expect(normalizeIntercomPayload(null)).toBeNull();
+    expect(normalizeIntercomPayload(undefined)).toBeNull();
+  });
+});
+
+describe("prepareIntercomAudioForTalk", () => {
+  it("encodes 1024-sample PCM Int16 LE via encodeImaAdpcm (516-byte block)", () => {
+    const pcm = new Int16Array(1024);
+    for (let i = 0; i < pcm.length; i++) {
+      pcm[i] = Math.round(4000 * Math.sin((2 * Math.PI * i) / 40));
+    }
+    const raw = Buffer.from(pcm.buffer, pcm.byteOffset, pcm.byteLength);
+    expect(raw.length).toBe(2048);
+
+    const out = prepareIntercomAudioForTalk(raw);
+    expect(out.length).toBe(516);
+    expect(out.equals(encodeImaAdpcm(pcm, 512))).toBe(true);
+    // First sample is 0 → zero predictor header; body should still have energy.
+    expect(out.subarray(4).some((b) => b !== 0)).toBe(true);
+  });
+
+  it("encodes 1025-sample PCM (one full block of samplesPerBlock)", () => {
+    const pcm = new Int16Array(1025);
+    pcm[0] = 1000;
+    for (let i = 1; i < pcm.length; i++) pcm[i] = 500;
+    const raw = Buffer.from(pcm.buffer, pcm.byteOffset, pcm.byteLength);
+    expect(raw.length).toBe(2050);
+    const out = prepareIntercomAudioForTalk(raw);
+    expect(out.length).toBe(516);
+    expect(out.readInt16LE(0)).toBe(1000);
+    expect(out[2]).toBe(0);
+  });
+
+  it("prepends zero header for legacy 512-byte nibble payloads", () => {
+    const nibbles = Buffer.alloc(512, 0x12);
+    const out = prepareIntercomAudioForTalk(nibbles);
+    expect(out.length).toBe(516);
+    expect(out.readUInt32LE(0)).toBe(0);
+    expect(out.subarray(4).equals(nibbles)).toBe(true);
+  });
+
+  it("passes through existing 516-byte full blocks", () => {
+    const full = Buffer.alloc(516, 0xab);
+    expect(prepareIntercomAudioForTalk(full).equals(full)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes silent two-way talk on native WebRTC intercom under **werift**, and ensures Reolink receives correctly framed ADPCM talk blocks.

### 1) Buffer / TypedArray payloads
werift delivers binary DataChannel messages as Node **`Buffer`**. The intercom handler only accepted **`ArrayBuffer`**, so mic audio was dropped with no error after the channel opened.

- Add `normalizeIntercomPayload()` for `Buffer | ArrayBuffer | ArrayBufferView`

### 2) PCM → `encodeImaAdpcm` on the server
Browser-side IMA ADPCM (nibble stream, or “header from encoder state + 1024 samples”) does **not** match Reolink TalkSession framing:

- first PCM sample as Int16 LE predictor  
- step index **0** per block  
- remaining samples → 512 ADPCM bytes → **516-byte** full blocks  

Preferred path: browser sends **raw PCM Int16 LE** (1024 samples = 2048 bytes, or 1025 = 2050). Server uses library `encodeImaAdpcm(pcm, 512)`.

Legacy:
- 512-byte nibble-only → zero header prepended (best-effort)
- 516-byte full blocks → pass through

## Change
- `normalizeIntercomPayload()` + `prepareIntercomAudioForTalk()` in `BaichuanWebRTCServer.ts`
- Unit tests in `test/lib/webrtc-intercom-payload.test.ts`

## Test plan
- [x] Manager restreamer = **local**, native WebRTC preview, mic → audible on Reolink doorbell/NVR channel
- [ ] `vitest` / CI: `test/lib/webrtc-intercom-payload.test.ts`
- [ ] Confirm logs show intercom forwards (not only channel open)

## Context
Verified against Reolink RLN8-410 + doorbell channel via Manager native WebRTC.

**Companion:** Manager UI changes in #42 (send PCM + `/worklets` static path). Merge **this PR first** (or both together).
