### PR TITLE
fix(manager): send PCM intercom + serve /worklets for AudioWorklet

### DIFF
--- a/app/client/src/components/cameras/WebRTCInlinePlayer.tsx
+++ b/app/client/src/components/cameras/WebRTCInlinePlayer.tsx
@@ -10,7 +10,7 @@ import {
   Minimize,
 } from "lucide-react";
 import { trpcMutation } from "../../api";
-import { ImaAdpcmEncoder, floatToPcm16 } from "./utils/imaAdpcm";
+import { floatToPcm16 } from "./utils/imaAdpcm";
 
 /**
  * WebRTC player driven by the in-process `BaichuanWebRTCServer` via the
@@ -18,10 +18,10 @@ import { ImaAdpcmEncoder, floatToPcm16 } from "./utils/imaAdpcm";
  * knows the camera codec); the browser answers and trickles its own ICE.
  *
  * The server also opens a bidirectional `intercom` DataChannel on demand:
- * the browser captures the mic, encodes IMA-ADPCM at 16 kHz mono, and ships
- * chunks of 1024 samples to the server which forwards them as BcMedia ADPCM
- * Talk frames to the camera. Downstream audio (camera → browser) already
- * flows on the standard Opus RTP track.
+ * the browser captures the mic at 16 kHz mono and ships raw PCM Int16 chunks
+ * (1024 samples) over the DC. The server encodes them with library
+ * `encodeImaAdpcm` into Reolink 516-byte talk blocks. Downstream audio
+ * (camera → browser) already flows on the standard Opus RTP track.
  */
 type Profile = "main" | "sub" | "ext";
 
@@ -84,11 +84,10 @@ export function WebRTCInlinePlayer({
   const audioContextRef = useRef<AudioContext | null>(null);
   const workletNodeRef = useRef<AudioWorkletNode | null>(null);
   const mediaStreamRef = useRef<MediaStream | null>(null);
-  const adpcmEncoderRef = useRef<ImaAdpcmEncoder | null>(null);
   /**
    * PCM accumulator: AudioWorklet posts ~128-sample bursts; we batch them
-   * to INTERCOM_CHUNK_SAMPLES before encoding so the camera receives
-   * predictably-sized BcMedia frames.
+   * to INTERCOM_CHUNK_SAMPLES before sending so the server receives
+   * predictably-sized PCM frames for encodeImaAdpcm.
    */
   const pcmBufferRef = useRef<Float32Array | null>(null);
   const pcmBufferLenRef = useRef(0);
@@ -126,7 +125,6 @@ export function WebRTCInlinePlayer({
     }
     pcmBufferRef.current = null;
     pcmBufferLenRef.current = 0;
-    adpcmEncoderRef.current?.reset();
     setMicActive(false);
   }, []);
 
@@ -473,22 +471,26 @@ export function WebRTCInlinePlayer({
           .webkitAudioContext);
       const ctx = new AudioCtx({ sampleRate: INTERCOM_SAMPLE_RATE });
       audioContextRef.current = ctx;
-      await ctx.audioWorklet.addModule("/worklets/pcm-tap.js");
+      // Served under /static/… in production (express.static). Dev Vite may
+      // still expose /worklets via publicDir — try static first, fall back.
+      try {
+        await ctx.audioWorklet.addModule("/static/worklets/pcm-tap.js");
+      } catch {
+        await ctx.audioWorklet.addModule("/worklets/pcm-tap.js");
+      }
       const source = ctx.createMediaStreamSource(ms);
       const node = new AudioWorkletNode(ctx, "pcm-tap", {
         numberOfInputs: 1,
         numberOfOutputs: 0,
         channelCount: 1,
       });
-      adpcmEncoderRef.current = new ImaAdpcmEncoder();
       pcmBufferRef.current = new Float32Array(INTERCOM_CHUNK_SAMPLES);
       pcmBufferLenRef.current = 0;
       node.port.onmessage = (ev: MessageEvent<Float32Array>) => {
         const samples = ev.data;
         const buf = pcmBufferRef.current;
-        const enc = adpcmEncoderRef.current;
         const dc = intercomChannelRef.current;
-        if (!buf || !enc || !dc || dc.readyState !== "open") return;
+        if (!buf || !dc || dc.readyState !== "open") return;
         let i = 0;
         while (i < samples.length) {
           const room = INTERCOM_CHUNK_SAMPLES - pcmBufferLenRef.current;
@@ -497,9 +499,16 @@ export function WebRTCInlinePlayer({
           pcmBufferLenRef.current += take;
           i += take;
           if (pcmBufferLenRef.current >= INTERCOM_CHUNK_SAMPLES) {
+            // Send raw PCM Int16 LE. The library WebRTC server encodes with
+            // encodeImaAdpcm so Reolink receives correct 516-byte talk blocks.
+            // Client-side ADPCM (even with a 4-byte header) does not match
+            // the camera's per-block framing and plays as silence.
             const pcm16 = floatToPcm16(buf);
-            const adpcm = enc.encode(pcm16);
-            try { dc.send(adpcm); } catch { /* drop on error */ }
+            try {
+              dc.send(pcm16);
+            } catch {
+              /* drop on error */
+            }
             pcmBufferLenRef.current = 0;
           }
         }

--- a/app/client/src/components/cameras/utils/imaAdpcm.ts
+++ b/app/client/src/components/cameras/utils/imaAdpcm.ts
@@ -1,18 +1,15 @@
 /**
- * Pure-JS IMA-ADPCM encoder, used to compress the browser's microphone PCM
- * before sending it over the WebRTC `intercom` DataChannel to the camera.
+ * Pure-JS IMA-ADPCM helpers for browser-side audio.
  *
- * Reolink cameras (per their TalkAbility response) expect 16-bit signed PCM
- * at 16 kHz mono, encoded into IMA-ADPCM nibbles (4 bits per input sample,
- * two samples per output byte). The state machine here is the standard
- * IMA ADPCM described in the Intel Indeo specification — same one used by
- * WAV codecs and most embedded talk-back stacks.
+ * Manager native intercom does **not** encode ADPCM in the browser anymore:
+ * `WebRTCInlinePlayer` sends raw PCM Int16 over the DataChannel and the
+ * library encodes with `encodeImaAdpcm` (correct Reolink block framing).
+ * {@link floatToPcm16} is what the player uses.
  *
- * Usage:
- *   const enc = new ImaAdpcmEncoder();
- *   const adpcmBytes = enc.encode(int16PcmSamples);
- *   // ... send to camera ...
- *   enc.reset(); // start a new utterance
+ * {@link ImaAdpcmEncoder} remains for experiments / alternate clients. Note
+ * that a naive "nibble stream + optional 4-byte header from encoder state"
+ * does **not** match Reolink TalkSession blocks (first sample as predictor,
+ * step index reset per block) — prefer server-side `encodeImaAdpcm`.
  */
 
 const STEP_TABLE: number[] = [

--- a/app/src/server.ts
+++ b/app/src/server.ts
@@ -394,6 +394,10 @@ appLogger.debug(`__dirname: ${__dirname}`, { source: "server" });
 appLogger.debug(`publicPath: ${publicPath}`, { source: "server" });
 if (hasBuiltUi) {
   app.use("/static", express.static(publicPath));
+  // AudioWorklet modules must be loaded by absolute URL. Older clients request
+  // /worklets/pcm-tap.js while production static assets live under /static/.
+  // Mount both so reverse proxies and cached UIs keep working.
+  app.use("/worklets", express.static(path.join(publicPath, "worklets")));
   appLogger.info(`Serving static files from: ${publicPath}`, {
     source: "server",
   });
@@ -906,6 +910,7 @@ app.get("*", (req, res, next) => {
     req.path.startsWith("/api") ||
     req.path.startsWith("/panel") ||
     req.path.startsWith("/static") ||
+    req.path.startsWith("/worklets") ||
     req.path.startsWith("/ws")
   ) {
     return next();


### PR DESCRIPTION
## Summary

Two Manager fixes for browser push-to-talk. **Depends on library #41** for the server-side PCM→ADPCM path.

### 1) Send PCM over the intercom DataChannel (not client ADPCM)
`WebRTCInlinePlayer` previously encoded IMA-ADPCM in the browser. Even with a 4-byte header derived from encoder state, that framing does **not** match Reolink TalkSession blocks (first sample as predictor, step index reset per block). Result: talk config succeeds, speaker stays silent.

- Batch mic samples to 1024 and send **raw PCM Int16** via `dc.send(pcm16)`
- Server (PR #41) encodes with library `encodeImaAdpcm(pcm, 512)` → 516-byte blocks
- Remove unused client `ImaAdpcmEncoder` usage from the player

### 2) AudioWorklet path
Production serves static assets under `/static/…`, but the player loaded `/worklets/pcm-tap.js`, which fell through the SPA fallback (HTML) and failed with:

`AbortError: unable to load a worklet's module`

- Mount `express.static` for `/worklets` as well as `/static`
- Prefer `/static/worklets/pcm-tap.js` with fallback to `/worklets/…`
- Exclude `/worklets` from SPA fallback

## Test plan
- [x] With #41: Manager restreamer = **local**, mic talk audible on camera
- [ ] Mic button works without worklet AbortError (no reverse-proxy worklets rewrite required)
- [ ] Without #41, PCM path will not encode — merge order matters

## Context
Verified on Reolink RLN8-410 + doorbell via Manager UI after server-side encode fix.

**Depends on:** #41
